### PR TITLE
Update the git tag check

### DIFF
--- a/roles/linux_preparation/files/get_refactor_version.sh
+++ b/roles/linux_preparation/files/get_refactor_version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-TAG=$(git log -n1 --pretty="format:%d" | sed "s/, /\n/g" | grep tag: | sed "s/tag: \|)//g" | tr -d '\n')
+TAG=$(git log -n1 --pretty="format:%d" | sed "s/, /\n/g" | grep tag: | grep -v origin | sed "s/tag: \|)//g" | tr -d '\n')
 
 if [[ $TAG == "" ]]; then
 	TAG=$(git reflog --decorate -1 | awk -F' ' '{print $1}' | tr -d '\n')


### PR DESCRIPTION
Fixing the git tag check that was returning the tag twice: as the tag name, then the full git ref tag (i.e. origin/tags/<tagname>).