### PR TITLE
Rcn base debian update

### DIFF
--- a/BaseLinux/replicape/Linux
+++ b/BaseLinux/replicape/Linux
@@ -1,6 +1,6 @@
 # This specifies the base Ubuntu system
-BASEIMAGE_DATE="2021-01-11"
-BASEIMAGE_UBUNTU_VERSION="10.7"
+BASEIMAGE_DATE="2021-02-22"
+BASEIMAGE_UBUNTU_VERSION="10.8"
 
 BASEIMAGE_URL=https://rcn-ee.com/rootfs/bb.org/testing/${BASEIMAGE_DATE}/buster-console/bone-debian-${BASEIMAGE_UBUNTU_VERSION}-console-armhf-${BASEIMAGE_DATE}-1gb.img.xz
 BASEIMAGE=`basename ${BASEIMAGE_URL}`

--- a/build-image-in-chroot-end-to-end.sh
+++ b/build-image-in-chroot-end-to-end.sh
@@ -70,7 +70,6 @@ mount ${DEVICE}p1 ${MOUNTPOINT}
 mount -o bind /dev ${MOUNTPOINT}/dev
 mount -o bind /sys ${MOUNTPOINT}/sys
 mount -o bind /proc ${MOUNTPOINT}/proc
-mount -o bind /dev/pts ${MOUNTPOINT}/dev/pts
 
 rm ${MOUNTPOINT}/etc/resolv.conf
 cp /etc/resolv.conf ${MOUNTPOINT}/etc/resolv.conf
@@ -104,10 +103,9 @@ rm -rf ${MOUNTPOINT}${REFACTOR_HOME}
 rm -rf ${MOUNTPOINT}/root/.ansible
 
 rm ${MOUNTPOINT}/etc/resolv.conf
+umount ${MOUNTPOINT}/dev
 umount ${MOUNTPOINT}/proc
 umount ${MOUNTPOINT}/sys
-umount -l ${MOUNTPOINT}/dev/pts
-umount ${MOUNTPOINT}/dev
 umount ${MOUNTPOINT}
 rmdir ${MOUNTPOINT}
 


### PR DESCRIPTION
A rather simple debian update for Replicape based boards, with a tweak in mounting/unmounting image filesystems for more reliable builds with the new version.